### PR TITLE
block doubly-opening open

### DIFF
--- a/add-on/lib/proxyblock.js
+++ b/add-on/lib/proxyblock.js
@@ -199,19 +199,22 @@
             }
         };
 
-        const oldWindowOpen = window.open;
-        const windowOpenProxy = new Proxy(window.open, {
-            apply: function (target, thisArg, argumentsList) {
-                console.log("window.open =", oldWindowOpen);
-                const wnd = oldWindowOpen.apply(thisArg, argumentsList);
-                featuresToBlock.forEach((v) => blockFeatureAtKeyPath(v, wnd));
-                return wnd;
-            }
-        });
-        Object.defineProperty(window, "open", {
-            get: () => windowOpenProxy
-        });
+        const blockOpen = function(window){
+            const oldWindowOpen = window.open;
+            const windowOpenProxy = new Proxy(window.open, {
+                apply: function (target, thisArg, argumentsList) {
+                    const wnd = oldWindowOpen.apply(thisArg, argumentsList);
+                    blockOpen(wnd);
+                    featuresToBlock.forEach((v) => blockFeatureAtKeyPath(v, wnd));
+                    return wnd;
+                }
+            });
+            Object.defineProperty(window, "open", {
+                get: () => windowOpenProxy
+            });
+        }
 
+        blockOpen(window);
         featuresToBlock.forEach((v) => blockFeatureAtKeyPath(v));
 
         // Next, delete the WEB_API_MANAGER_PAGE global property.  Technically


### PR DESCRIPTION
When, for example the Battery Status API is blocked,
you can still access the blocked properties via

```
open('chrome://extensions').open('chrome://extensions').navigator.getBattery()
````
because the returned window object does not have open blocked.

This fixes that by creating a `blockOpen` function which also runs on windows returned by `open`.

I think there is still a problem in that not all of `proxyBlockingFunction` is executed on the returned window, in particular not the frame-modifying stuff https://github.com/iptq/web-api-manager/blob/90b2e60c712ada7a07090f40fb70ee55ed80d65f/add-on/lib/proxyblock.js#L238-L245